### PR TITLE
Add jetstack repository to repos.yaml

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -59,3 +59,11 @@ repositories:
         name: Gilad Weiss
       - email: ori.shoshan@rookout.com
         name: Ori Shoshan
+  - name: jetstack
+    type: helm
+    url: https://charts.jetstack.io/
+    maintainers:
+      - email: cert-manager-maintainers@jetstack.io
+        name: cert-manager project maintainers
+      - email: james@munnelly.eu
+        name: James Munnelly


### PR DESCRIPTION
Explicitly adds the `charts.jetstack.io` Helm repository to repos.yaml 🎉 

We have an email alias for maintainers now, so I have added that, as well as myself too so there is a 'human' contact with a name 😄