### PR TITLE
Add scm-manager helm repository

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -137,3 +137,13 @@ repositories:
     maintainers:
       - name: Ievgenii Shepeliuk
         email: eshepelyuk@gmail.com
+  - name: scm-manager
+    type: helm
+    url: https://packages.scm-manager.org/repository/helm-v2-releases/
+    maintainers:
+      - name: Sebastian Sdorra
+        email: sebastian.sdorra@cloudogu.com
+      - name: René Pfeuffer
+        email: rene.pfeuffer@cloudogu.com
+      - name: Eduard Heimbuch
+        email: eduard.heimbuch@cloudogu.com 


### PR DESCRIPTION
Add helm repository for [SCM-Manager 2 ](https://scm-manager.org).
The missing maintainer information will be added with the next release of the chart ([a680b75](https://github.com/scm-manager/scm-manager/commit/a680b75f856567282943678bae28d54e9ce80cda)).